### PR TITLE
Support multiple health check publishers

### DIFF
--- a/AspNetCore.Diagnostics.HealthChecks.Background/AspNetCore.Diagnostics.HealthChecks.Background.csproj
+++ b/AspNetCore.Diagnostics.HealthChecks.Background/AspNetCore.Diagnostics.HealthChecks.Background.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 <PropertyGroup>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>Execute health checks in the background and return their results at the health endpoint</Description>
     <PackageProjectUrl>https://github.com/wjdavis5/AspNetCore.Diagnostics.HealthChecks.Background</PackageProjectUrl>

--- a/AspNetCore.Diagnostics.HealthChecks.Background/BackgroundHealthCheckMiddleware.cs
+++ b/AspNetCore.Diagnostics.HealthChecks.Background/BackgroundHealthCheckMiddleware.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using AspNetCore.Diagnostics.HealthChecks.Background;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -26,7 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection
             RequestDelegate next,
             IOptions<HealthCheckOptions> healthCheckOptions,
             HealthCheckService healthCheckService,
-            IHealthCheckPublisher healthCheckPublisher)
+            IEnumerable<IHealthCheckPublisher> healthCheckPublishers)
         {
             if (next == null)
             {
@@ -46,8 +48,14 @@ namespace Microsoft.Extensions.DependencyInjection
             _next = next;
             _healthCheckOptions = healthCheckOptions.Value;
             _healthCheckService = healthCheckService;
-            _healthCheckPublisher = healthCheckPublisher as BackgroundHealthCheckPublisher 
-                ?? throw new ArgumentException("Invalid health check publisher type.", nameof(healthCheckPublisher));
+            foreach(var healthCheckPublisher in healthCheckPublishers)
+            {
+                if (healthCheckPublisher is BackgroundHealthCheckPublisher backgroundHealthCheckPublisher)
+                {
+                    _healthCheckPublisher = backgroundHealthCheckPublisher;
+                    break;
+                }
+            }
         }
 
         /// <summary>

--- a/AspNetCore.Diagnostics.HealthChecks.Background/BackgroundHealthCheckMiddleware.cs
+++ b/AspNetCore.Diagnostics.HealthChecks.Background/BackgroundHealthCheckMiddleware.cs
@@ -56,6 +56,10 @@ namespace Microsoft.Extensions.DependencyInjection
                     break;
                 }
             }
+            if (_healthCheckPublisher == null)
+            {
+                throw new InvalidOperationException("No BackgroundHealthCheckPublisher found.");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Use IEnumerable<IHealthCheckPublisher> in the middleware and grab the one we want.